### PR TITLE
Correct behavior for resample_factor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Contributors:
 * Eloy Félix <eloyfelix>
 * René Hafner (Hamburger) <renehamburger1993>
 * Lily Wang <lilyminium>
+* Josh Vermaas <jvermaas>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,7 @@ The rules for this file:
   * accompany each entry with github issue/PR number (Issue #xyz)
 
 ------------------------------------------------------------------------------
-??/??/2019 eloyfelix, renehamburger1993, lilyminium
+??/??/2019 eloyfelix, renehamburger1993, lilyminium, jvermaas
 
   * 0.6.0
 
@@ -26,6 +26,8 @@ The rules for this file:
 
   * fix initialization of mutable instance variable of Grid class (metadata dict) (#71)
   * fix multiple __init__ calls (#73)
+  * interpolation behavior outside of the grid changed to default to a
+   constant rather than the nearest value (#84)
 
 
 05/16/2019 giacomofiorin, orbeckst


### PR DESCRIPTION
The reason tests were failing for the previous commit was that
resample_factor was depending on "nearest" interpolation to correct
for not altering the range where the edge points were calculated.
By correctly calculating an even distribution of edge points,
interpolation at "midpoints" no longer occurs outside the defined grid.